### PR TITLE
Add reusable issue-pr-tag workflow

### DIFF
--- a/.github/workflows/issue-pr-tag.yml
+++ b/.github/workflows/issue-pr-tag.yml
@@ -1,0 +1,24 @@
+name: "Issue/PR Tag"
+
+# Trigger workflow when issues or pull requests are opened/edited,
+# or when this workflow file is modified
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  notify:
+    uses: devops-actions/.github/.github/workflows/issue-pr-tag.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      org_name: ${{ vars.FIXED_ORG_NAME }}
+      tag_team: ${{ vars.TAG_TEAM }}
+      issue: ${{ github.event.issue.number }}
+      pr: ${{ github.event.pull_request.number }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the reusable issue-pr-tag workflow, referencing the shared workflow in devops-actions/.github.